### PR TITLE
solve issue of low contrast

### DIFF
--- a/res/layout/login.xml
+++ b/res/layout/login.xml
@@ -8,11 +8,11 @@
     
     <CheckBox android:id="@+id/google_login" android:textColor="#333333" android:text="Google Login" android:layout_width="wrap_content" android:layout_height="wrap_content" />
     
-    <TextView android:text="Email" android:paddingLeft="3dp" android:paddingTop="6dp" android:layout_width="wrap_content" android:layout_height="wrap_content" />
+    <TextView android:text="Email" android:textColor="#555555" android:paddingLeft="3dp" android:paddingTop="6dp" android:layout_width="wrap_content" android:layout_height="wrap_content" />
     <EditText android:inputType="textEmailAddress" android:layout_height="wrap_content" android:layout_width="fill_parent" android:id="@+id/login_email" android:text="" android:layout_marginRight="5dp" />
     
     <LinearLayout android:orientation="vertical" android:id="@+id/password_container" android:layout_height="wrap_content" android:layout_width="fill_parent">
-	    <TextView android:text="Password" android:paddingLeft="3dp" android:paddingTop="6dp" android:layout_width="wrap_content" android:layout_height="wrap_content" />
+	    <TextView android:text="Password" android:textColor="#555555" android:paddingLeft="3dp" android:paddingTop="6dp" android:layout_width="wrap_content" android:layout_height="wrap_content" />
 	    <EditText android:inputType="textPassword" android:layout_height="wrap_content" android:layout_width="fill_parent" android:id="@+id/login_password" android:text="" android:layout_marginRight="5dp" />
     </LinearLayout>
     

--- a/res/layout/register.xml
+++ b/res/layout/register.xml
@@ -8,10 +8,10 @@
     <TextView android:text="Name" android:paddingLeft="3dp" android:paddingTop="6dp" android:layout_width="wrap_content" android:layout_height="wrap_content" />
     <EditText android:inputType="textPersonName" android:layout_height="wrap_content" android:layout_width="fill_parent" android:id="@+id/register_full_name" android:text="" android:layout_marginRight="5dp" />
    
-    <TextView android:text="Email" android:paddingLeft="3dp" android:paddingTop="6dp" android:layout_width="wrap_content" android:layout_height="wrap_content" />
+    <TextView android:text="Email" android:textColor="#555555" android:paddingLeft="3dp" android:paddingTop="6dp" android:layout_width="wrap_content" android:layout_height="wrap_content" />
     <EditText android:inputType="textEmailAddress" android:layout_height="wrap_content" android:layout_width="fill_parent" android:id="@+id/register_email" android:text="" android:layout_marginRight="5dp" />
     
-    <TextView android:text="Password" android:paddingLeft="3dp" android:paddingTop="6dp" android:layout_width="wrap_content" android:layout_height="wrap_content" />
+    <TextView android:text="Password" android:textColor="#555555" android:paddingLeft="3dp" android:paddingTop="6dp" android:layout_width="wrap_content" android:layout_height="wrap_content" />
     <EditText android:inputType="textPassword" android:layout_height="wrap_content" android:layout_width="fill_parent" android:id="@+id/register_password" android:text="" android:layout_marginRight="5dp" />
     
    <LinearLayout android:layout_height="wrap_content" android:layout_width="fill_parent" android:gravity="center" android:layout_marginTop="20dp">


### PR DESCRIPTION
The original text color of the component is '#BEBEBE', and the contrast between the text color ('#BEBEBE') and the background color ('#FFFFFFF') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#555555') are as follows:
![image](https://user-images.githubusercontent.com/101503193/158405784-2399c801-0665-4fc4-97f3-5d09a2387e4c.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.